### PR TITLE
Add loop guard to PreMadePlanetSystem.orbit_inward

### DIFF
--- a/stargen/premadeplanetsystem.py
+++ b/stargen/premadeplanetsystem.py
@@ -208,7 +208,14 @@ class PreMadePlanetSystem:
         oldorbit = startorbit
         print(startorbit)
         neworbit = 0
-        while (allowed):
+        iteration_count = 0  # Add a counter to prevent infinite loops
+        max_iterations = 100  # Set a maximum number of iterations
+
+        while allowed:
+            iteration_count += 1
+            if iteration_count > max_iterations:
+                print("Max iterations reached, exiting loop to prevent infinite loop.")
+                break
             orbsep = OrbitalSpace[self.roller.roll_dice(3, 0)]
             neworbit = oldorbit / orbsep
             #print(neworbit)


### PR DESCRIPTION
## Summary
- prevent runaway loops in `PreMadePlanetSystem.orbit_inward` by counting iterations and limiting to 100

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431e488be0832abcff2125181ea09a