### PR TITLE
Wrap run script logic in main guard

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,12 +2,17 @@ from stargen import StarSystem
 from stargen.utils.latexout import LatexWriter
 from stargen.utils.random_name import generate_random_name
 
-filename = f"{generate_random_name()}.tex"
-#testsystem = StarSystem()
-star = StarSystem()
-tex = LatexWriter(star, filename)
+def main():
+    filename = f"{generate_random_name()}.tex"
+    # testsystem = StarSystem()
+    star = StarSystem()
+    tex = LatexWriter(star, filename)
 
-star.print_info()
-tex.write()
+    star.print_info()
+    tex.write()
 
-print(filename)
+    print(filename)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- prevent execution of `run.py` when imported by wrapping the script logic in `if __name__ == '__main__':`

## Testing
- `python -m py_compile run.py`

------
https://chatgpt.com/codex/tasks/task_e_68431e45f4e0832a872d62393c058293