### PR TITLE
Fix latex writer path creation

### DIFF
--- a/stargen/utils/latexout.py
+++ b/stargen/utils/latexout.py
@@ -6,6 +6,7 @@ processing towards a nicely formatted PDF file.
 
 # from ..starsystem import StarSystem
 from ..data.tables import AtmCompAbbr
+import os
 
 class LatexWriter:
     def __init__(self, starsystem, filename='starsystem.tex'):
@@ -14,8 +15,9 @@ class LatexWriter:
 
     def write(self):
         # Ensure the file is saved in the 'text' directory
+        os.makedirs('text', exist_ok=True)
         filepath = f"text/{self.filename}"
-        
+
         # Open the file
         file = open(filepath, 'w')
 


### PR DESCRIPTION
## Summary
- ensure text output directory exists before writing

## Testing
- `python -m compileall -q stargen/utils/latexout.py`

------
https://chatgpt.com/codex/tasks/task_e_68431e42c0e8832ab39ef300f39cb2fb