### PR TITLE
Use white background for world maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ pip install -r requirements.txt
 Run `run.py` to generate LaTeX and GIF outputs for a random star system. GIFs
 are saved in the `gifs/` directory and are named after the generated random
 system name with the star letter appended when multiple stars are present.
+World maps for any generated Garden worlds are saved as PNGs in the `maps/`
+directory using the same system name and planet identifier.

--- a/run.py
+++ b/run.py
@@ -8,6 +8,11 @@ def main():
     except ImportError:
         render_system_gif = None
 
+    try:
+        from stargen.utils.mapmaker import generate_world_map
+    except ImportError:
+        generate_world_map = None
+
     name = generate_random_name()
     filename = f"{name}.tex"
     # testsystem = StarSystem()
@@ -21,6 +26,19 @@ def main():
         render_system_gif(star_system, f"gifs/{name}.gif")
     else:
         print("GIF generation skipped: missing dependencies")
+
+    if generate_world_map:
+        for star in star_system.stars:
+            oc_dict = star.planetsystem.get_orbitcontents()
+            for oc in oc_dict.values():
+                if hasattr(oc, 'get_type') and oc.get_type() == 'Garden':
+                    hydro = oc.get_hydrographic_cover()
+                    generate_world_map(
+                        f"maps/{name}_{oc.get_name()}.png",
+                        hydro,
+                    )
+    else:
+        print("Map generation skipped: missing dependencies")
 
     print(filename)
 

--- a/stargen/utils/mapmaker.py
+++ b/stargen/utils/mapmaker.py
@@ -1,37 +1,70 @@
+"""Simple procedural world map generator."""
+
+import os
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.ndimage import gaussian_filter
 import cartopy.crs as ccrs
 from matplotlib.colors import ListedColormap
 
-# Set up a grid in latitude and longitude.
-# Mercator projection typically excludes the poles, so we limit latitude to about ±85°.
-n_lon = 720   # resolution in longitude
-n_lat = 340   # resolution in latitude
-lon = np.linspace(-180, 180, n_lon)
-lat = np.linspace(-85, 85, n_lat)
 
-# Create a random noise field and smooth it to simulate realistic continent shapes.
-noise = np.random.rand(n_lat, n_lon)
-smooth_noise = gaussian_filter(noise, sigma=10)
+def generate_world_map(filepath: str, hydrographic_cover: int) -> None:
+    """Generate a random world map and save it as ``filepath``.
 
-# Determine a threshold that yields ~55% land (i.e. 55% of pixels above the threshold).
-threshold = np.percentile(smooth_noise, 45)
-land_mask = smooth_noise > threshold
+    Parameters
+    ----------
+    filepath:
+        Path of the PNG file to create.
+    hydrographic_cover:
+        Percentage of the world's surface covered by water (0-100).
+    
+    The resulting map is rendered on a plain white background.
+    """
 
-# Define a custom colormap: water in blue, land in green.
-cmap = ListedColormap(['deepskyblue', 'forestgreen'])
+    # Create output directory if needed
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
 
-# Plot the world map using a Mercator projection.
-fig = plt.figure(figsize=(12, 6))
-ax = plt.axes(projection=ccrs.Mercator())
-ax.set_global()
-ax.coastlines(linewidth=1)
+    # Set up a grid in latitude and longitude. Mercator projection typically
+    # excludes the poles, so we limit latitude to about ±85°.
+    n_lon = 720   # resolution in longitude
+    n_lat = 340   # resolution in latitude
+    lon = np.linspace(-180, 180, n_lon)
+    lat = np.linspace(-85, 85, n_lat)
 
-# Plot the land/water mask.
-# The image is plotted in PlateCarree coordinate space.
-ax.imshow(land_mask, origin='upper', extent=[-180, 180, -85, 85],
-          transform=ccrs.PlateCarree(), cmap=cmap)
+    # Create a random noise field and smooth it to simulate realistic continent
+    # shapes.
+    noise = np.random.rand(n_lat, n_lon)
+    smooth_noise = gaussian_filter(noise, sigma=10)
 
-ax.set_title("Example World Map (45% Water, 55% Land)")
-plt.show()
+    # Determine a threshold based on the requested hydrographic coverage.
+    # ``hydrographic_cover`` represents the percentage of water, so we keep
+    # that fraction of pixels below the threshold.
+    threshold = np.percentile(smooth_noise, hydrographic_cover)
+    land_mask = smooth_noise > threshold
+
+    # Define a custom colormap: water in blue, land in green.
+    cmap = ListedColormap(['deepskyblue', 'forestgreen'])
+
+    # Plot the world map using a Mercator projection.
+    fig = plt.figure(figsize=(12, 6))
+    ax = plt.axes(projection=ccrs.Mercator())
+    ax.set_global()
+    ax.set_facecolor("white")
+    ax.coastlines(linewidth=1)
+
+    # Plot the land/water mask. The image is plotted in PlateCarree coordinate
+    # space.
+    ax.imshow(
+        land_mask,
+        origin="upper",
+        extent=[-180, 180, -85, 85],
+        transform=ccrs.PlateCarree(),
+        cmap=cmap,
+    )
+
+    water = hydrographic_cover
+    land = 100 - water
+    ax.set_title(f"Example World Map ({water}% Water, {land}% Land)")
+    plt.savefig(filepath, bbox_inches="tight")
+    plt.close(fig)
+

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -5,18 +5,35 @@ import sys
 import run
 
 class TestRun(unittest.TestCase):
-    @patch.dict('sys.modules', {'stargen.utils.gifout': SimpleNamespace(render_system_gif=MagicMock())})
+    @patch.dict(
+        'sys.modules',
+        {
+            'stargen.utils.gifout': SimpleNamespace(render_system_gif=MagicMock()),
+            'stargen.utils.mapmaker': SimpleNamespace(generate_world_map=MagicMock()),
+        },
+    )
     @patch('run.StarSystem')
     @patch('run.LatexWriter')
     @patch('run.generate_random_name', return_value='testname')
     def test_main(self, gen_name, LatexWriterMock, StarSystemMock):
+        world = MagicMock()
+        world.get_name.return_value = 'A4'
+        world.get_type.return_value = 'Garden'
+        world.get_hydrographic_cover.return_value = 30
+        ps = MagicMock()
+        ps.get_orbitcontents.return_value = {'a': world}
+        star = MagicMock(planetsystem=ps)
+        StarSystemMock.return_value.stars = [star]
         instance = StarSystemMock.return_value
         tex_instance = LatexWriterMock.return_value
+
         run.main()
+
         StarSystemMock.assert_called_once()
         LatexWriterMock.assert_called_once_with(instance, 'testname.tex')
         tex_instance.write.assert_called()
         sys.modules['stargen.utils.gifout'].render_system_gif.assert_called_once_with(instance, 'gifs/testname.gif')
+        sys.modules['stargen.utils.mapmaker'].generate_world_map.assert_called_once_with('maps/testname_A4.png', 30)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- drop the Cartopy Earth texture from `generate_world_map`
- document that maps are rendered on a plain white background

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843e24c2f20832abfca54acaea4ecbe