### PR TITLE
Fix module imports for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the package root is on the Python path so tests can import stargen
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- fix module import path so `pytest` works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844190b1490832a8a7d00aa7b0a38df