### PR TITLE
Add JSON serialization support

### DIFF
--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@ from stargen.utils.dokuwikiout import DokuwikiWriter
 from stargen.utils.random_name import generate_random_name
 from stargen.utils.gifout import render_system_gif
 from stargen.utils.mapmaker import generate_world_map
+from stargen.utils.serializer import dump_json
 
 def main(args=None):
     print(args)
@@ -15,6 +16,12 @@ def main(args=None):
         choices=["latex", "dokuwiki"],
         default="latex",
         help="Output format",
+    )
+    parser.add_argument(
+        "--json",
+        metavar="FILE",
+        help="Write JSON representation to FILE",
+        default=None,
     )
     if args is None:
         args = []
@@ -35,6 +42,9 @@ def main(args=None):
 
     star_system.print_info()
     writer.write()
+
+    if parsed.json:
+        dump_json(star_system, parsed.json)
 
     system_gif = input("Do you want a gif of the system? [Y/N]: ")
     world_map = input("Do you want a map of the garden world(s)? [Y/N]: ")

--- a/stargen/utils/serializer.py
+++ b/stargen/utils/serializer.py
@@ -1,0 +1,73 @@
+import json
+
+
+def serialize_orbit_content(oc):
+    data = {
+        "class": oc.__class__.__name__,
+        "name": getattr(oc, "name", ""),
+        "orbit": oc.get_orbit() if hasattr(oc, "get_orbit") else None,
+        "period": oc.get_period() if hasattr(oc, "get_period") else None,
+        "eccentricity": oc.get_eccentricity() if hasattr(oc, "get_eccentricity") else None,
+    }
+    if hasattr(oc, "get_type"):
+        data["type"] = oc.get_type()
+    elif hasattr(oc, "type"):
+        data["type"] = oc.type()
+    if hasattr(oc, "get_size"):
+        data["size"] = oc.get_size()
+    if hasattr(oc, "get_mass"):
+        try:
+            data["mass"] = oc.get_mass()
+        except Exception:
+            pass
+    if hasattr(oc, "num_moons"):
+        data["moons"] = oc.num_moons()
+    if hasattr(oc, "num_moonlets"):
+        data["moonlets"] = oc.num_moonlets()
+    if hasattr(oc, "get_hydrographic_cover"):
+        data["hydrographic_cover"] = oc.get_hydrographic_cover()
+    return data
+
+
+def serialize_planet_system(ps):
+    return {
+        "gasarrangement": getattr(ps, "gasarrangement", None),
+        "first_gas_orbit": getattr(ps, "firstgasorbit", None),
+        "orbits": getattr(ps, "orbitarray", []),
+        "orbitcontents": {str(k): serialize_orbit_content(v) for k, v in getattr(ps, "orbitcontents", {}).items()},
+    }
+
+
+def serialize_star(star):
+    data = {
+        "letter": star.get_letter() if hasattr(star, "get_letter") else None,
+        "mass": star.get_mass() if hasattr(star, "get_mass") else None,
+        "sequence": star.get_sequence() if hasattr(star, "get_sequence") else None,
+        "temperature": star.get_temp() if hasattr(star, "get_temp") else None,
+        "luminosity": star.get_luminosity() if hasattr(star, "get_luminosity") else None,
+        "radius": star.get_radius() if hasattr(star, "get_radius") else None,
+        "age": star.get_age() if hasattr(star, "get_age") else None,
+        "orbit_limits": star.get_orbit_limits() if hasattr(star, "get_orbit_limits") else None,
+        "snowline": star.get_snowline() if hasattr(star, "get_snowline") else None,
+    }
+    if hasattr(star, "has_forbidden_zone") and star.has_forbidden_zone():
+        data["forbidden_zone"] = star.get_forbidden_zone()
+    if hasattr(star, "planetsystem") and star.planetsystem is not None:
+        data["planetsystem"] = serialize_planet_system(star.planetsystem)
+    return data
+
+
+def serialize_star_system(system):
+    return {
+        "age": system.get_age() if hasattr(system, "get_age") else None,
+        "open_cluster": system.is_open_cluster() if hasattr(system, "is_open_cluster") else None,
+        "orbits": system.get_orbits() if hasattr(system, "get_orbits") else None,
+        "periods": system.get_period() if hasattr(system, "get_period") else None,
+        "stars": [serialize_star(s) for s in getattr(system, "stars", [])],
+    }
+
+
+def dump_json(system, path):
+    with open(path, "w") as f:
+        json.dump(serialize_star_system(system), f, indent=2)
+

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,17 +1,16 @@
 import unittest
 from unittest.mock import patch, MagicMock
+import json
 from types import SimpleNamespace
 import sys
+
+# Provide stub modules to avoid heavy optional dependencies during import
+sys.modules.setdefault('stargen.utils.gifout', SimpleNamespace(render_system_gif=MagicMock()))
+sys.modules.setdefault('stargen.utils.mapmaker', SimpleNamespace(generate_world_map=MagicMock()))
+
 import run
 
 class TestRun(unittest.TestCase):
-    @patch.dict(
-        'sys.modules',
-        {
-            'stargen.utils.gifout': SimpleNamespace(render_system_gif=MagicMock()),
-            'stargen.utils.mapmaker': SimpleNamespace(generate_world_map=MagicMock()),
-        },
-    )
     @patch('run.StarSystem')
     @patch('run.DokuwikiWriter')
     @patch('run.LatexWriter')
@@ -37,13 +36,6 @@ class TestRun(unittest.TestCase):
         sys.modules['stargen.utils.gifout'].render_system_gif.assert_called_once_with(instance, 'gifs/testname.gif')
         sys.modules['stargen.utils.mapmaker'].generate_world_map.assert_called_once_with('maps/testname_A4.png', 30)
 
-    @patch.dict(
-        'sys.modules',
-        {
-            'stargen.utils.gifout': SimpleNamespace(render_system_gif=MagicMock()),
-            'stargen.utils.mapmaker': SimpleNamespace(generate_world_map=MagicMock()),
-        },
-    )
     @patch('run.StarSystem')
     @patch('run.DokuwikiWriter')
     @patch('run.LatexWriter')
@@ -66,6 +58,26 @@ class TestRun(unittest.TestCase):
         StarSystemMock.assert_called_once()
         DokuwikiMock.assert_called_once_with(instance, 'testname.txt')
         wiki_instance.write.assert_called()
+
+    @patch('run.StarSystem')
+    @patch('run.DokuwikiWriter')
+    @patch('run.LatexWriter')
+    @patch('run.generate_random_name', return_value='testname')
+    @patch('builtins.input', side_effect=['n', 'n'])
+    def test_main_json(self, input_mock, gen_name, LatexWriterMock, DokuwikiMock, StarSystemMock):
+        star_system = StarSystemMock.return_value
+        star_system.stars = []
+        star_system.get_age.return_value = 1
+        star_system.is_open_cluster.return_value = False
+        star_system.get_orbits.return_value = []
+        star_system.get_period.return_value = []
+
+        run.main(['--json', 'out.json'])
+
+        StarSystemMock.assert_called_once()
+        with open('out.json') as f:
+            data = json.load(f)
+        self.assertIn('stars', data)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,87 @@
+import unittest
+from stargen.utils.serializer import serialize_star_system
+
+class DummyOrbitContent:
+    def __init__(self):
+        self.name = 'A1'
+    def get_orbit(self):
+        return 1.0
+    def get_period(self):
+        return 1.0
+    def get_eccentricity(self):
+        return 0.0
+    def get_type(self):
+        return 'Rock'
+    def get_size(self):
+        return 'Small'
+    def num_moons(self):
+        return 0
+    def num_moonlets(self):
+        return 0
+    def get_hydrographic_cover(self):
+        return 0
+
+class DummyPlanetSystem:
+    def __init__(self):
+        self.gasarrangement = 'None'
+        self.firstgasorbit = None
+        self.orbitarray = [1.0]
+        self.orbitcontents = {1.0: DummyOrbitContent()}
+    def get_orbitcontents(self):
+        return self.orbitcontents
+
+class DummyStar:
+    def __init__(self):
+        self.planetsystem = DummyPlanetSystem()
+    def get_letter(self):
+        return 'A'
+    def get_mass(self):
+        return 1.0
+    def get_sequence(self):
+        return 'G'
+    def get_temp(self):
+        return 5800
+    def get_luminosity(self):
+        return 1.0
+    def get_radius(self):
+        return 1.0
+    def get_age(self):
+        return 5
+    def get_orbit_limits(self):
+        return (0.1, 40.0)
+    def get_snowline(self):
+        return 1.0
+    def has_forbidden_zone(self):
+        return False
+
+class DummySystem:
+    def __init__(self):
+        self.stars = [DummyStar()]
+        self.age = 5
+        self.open_cluster = False
+        self.orbits = []
+        self.periods = []
+    def get_age(self):
+        return self.age
+    def is_open_cluster(self):
+        return self.open_cluster
+    def get_orbits(self):
+        return self.orbits
+    def get_period(self):
+        return self.periods
+
+class TestSerializer(unittest.TestCase):
+    def test_serialize_simple_system(self):
+        system = DummySystem()
+        data = serialize_star_system(system)
+        self.assertEqual(data['age'], 5)
+        self.assertEqual(len(data['stars']), 1)
+        star = data['stars'][0]
+        self.assertEqual(star['letter'], 'A')
+        self.assertIn('planetsystem', star)
+        ps = star['planetsystem']
+        self.assertIn('orbitcontents', ps)
+        self.assertEqual(list(ps['orbitcontents'].keys()), ['1.0'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement serializer utilities for star systems
- support `--json <file>` flag in CLI
- add tests for JSON output and serializer
- update run tests to work without heavy deps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447ec990c0832a9cb8e7ab0252fd63